### PR TITLE
Fix order dependent component registration issue

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -23,6 +23,17 @@ type goatTemplate struct {
 }
 
 func (t *goatTemplate) parse(text string, components map[string]bool) {
+	t.rawContent = text
+	t.potentialReferencedComponents = make(map[string]bool)
+
+	// If we have no potentially referenced components that might require
+	// recompilation, we can save some space and remove the content
+	defer func() {
+		if len(t.potentialReferencedComponents) == 0 {
+			t.rawContent = ""
+		}
+	}()
+
 	runes := []rune(text)
 	nodes := make([]*Node, 0)
 


### PR DESCRIPTION
Due to the way Go and this library works, it's necessary to know what
components exist vs what is just HTML in the templat that looks like
a template.

This makes some trade-offs, specifically requiring that we spend
redundant time re-generating the template when a component is
registered after the template is parsed.

Additionally, we hold onto the raw content of the template so we can
recompile it if necessary.
